### PR TITLE
Negative Voltage Fix

### DIFF
--- a/source/daisy.field.json
+++ b/source/daisy.field.json
@@ -1,14 +1,20 @@
 {
-    "max_apps":8,
+	"max_apps": 8,
 	"defines": {
 		"OOPSY_TARGET_FIELD": 1,
 		"OOPSY_TARGET_HAS_OLED": 1,
 		"OOPSY_TARGET_HAS_MIDI_INPUT": 1,
 		"OOPSY_TARGET_HAS_MIDI_OUTPUT": 1
 	},
-    "inserts": [
-		{ "where": "header", "code": "#include \"daisy_field.h\"" },
-		{ "where": "header", "code": "typedef daisy::DaisyField Daisy;" }
+	"inserts": [
+		{
+			"where": "header",
+			"code": "#include \"daisy_field.h\""
+		},
+		{
+			"where": "header",
+			"code": "typedef daisy::DaisyField Daisy;"
+		}
 	],
 	"labels": {
 		"params": {
@@ -43,7 +49,6 @@
 			"cv3": "cv3",
 			"cv4": "cv4",
 			"gate1": "gt1",
-
 			"key1": "kA1",
 			"key2": "kA2",
 			"key3": "kA3",
@@ -70,7 +75,6 @@
 			"ctrl8": "kn8",
 			"switch1": "sw1",
 			"switch2": "sw2",
-
 			"knob": "kn",
 			"key": "kA1",
 			"ctrl": "kn",
@@ -92,35 +96,35 @@
 	"inputs": {
 		"kn1": {
 			"automap": true,
-        	"code": "hardware.GetKnobValue(hardware.KNOB_1);"
+			"code": "hardware.GetKnobValue(hardware.KNOB_1);"
 		},
 		"kn2": {
 			"automap": true,
-        	"code": "hardware.GetKnobValue(hardware.KNOB_2);"
+			"code": "hardware.GetKnobValue(hardware.KNOB_2);"
 		},
 		"kn3": {
 			"automap": true,
-        	"code": "hardware.GetKnobValue(hardware.KNOB_3);"
+			"code": "hardware.GetKnobValue(hardware.KNOB_3);"
 		},
 		"kn4": {
 			"automap": true,
-        	"code": "hardware.GetKnobValue(hardware.KNOB_4);"
+			"code": "hardware.GetKnobValue(hardware.KNOB_4);"
 		},
 		"kn5": {
 			"automap": true,
-        	"code": "hardware.GetKnobValue(hardware.KNOB_5);"
+			"code": "hardware.GetKnobValue(hardware.KNOB_5);"
 		},
 		"kn6": {
 			"automap": true,
-        	"code": "hardware.GetKnobValue(hardware.KNOB_6);"
+			"code": "hardware.GetKnobValue(hardware.KNOB_6);"
 		},
 		"kn7": {
 			"automap": true,
-        	"code": "hardware.GetKnobValue(hardware.KNOB_7);"
+			"code": "hardware.GetKnobValue(hardware.KNOB_7);"
 		},
 		"kn8": {
 			"automap": true,
-        	"code": "hardware.GetKnobValue(hardware.KNOB_8);"
+			"code": "hardware.GetKnobValue(hardware.KNOB_8);"
 		},
 		"kA1": {
 			"code": "(hardware.KeyboardState(0)?1.f:0.f);"
@@ -177,23 +181,19 @@
 			"code": "(hardware.GetSwitch(1)->Pressed()?1.f:0.f);"
 		},
 		"cv1": {
-			"input_min": -1,
-			"input_max": 1,
+			"range": [-1, 1],
 			"code": "hardware.GetCvValue(0);"
 		},
 		"cv2": {
-			"input_min": -1,
-			"input_max": 1,
+			"range": [-1, 1],
 			"code": "hardware.GetCvValue(1);"
 		},
 		"cv3": {
-			"input_min": -1,
-			"input_max": 1,
+			"range": [-1, 1],
 			"code": "hardware.GetCvValue(2);"
 		},
 		"cv4": {
-			"input_min": -1,
-			"input_max": 1,
+			"range": [-1, 1],
 			"code": "hardware.GetCvValue(3);"
 		},
 		"gt1": {
@@ -202,21 +202,21 @@
 	},
 	"outputs": {
 		"cvout1": {
-			"where":"main",
+			"where": "main",
 			"code": "hardware.SetCvOut1($<name> * 4095);"
 		},
 		"cvout2": {
-			"where":"main",
+			"where": "main",
 			"code": "hardware.SetCvOut2($<name> * 4095);"
 		},
 		"gateout1": {
-			"where":"audio",
+			"where": "audio",
 			"code": "dsy_gpio_write(&hardware.gate_out, $<name> > 0.f);"
 		}
 	},
 	"datahandlers": {
 		"dsy_leds": {
-			"where":"display",
+			"where": "display",
 			"code": "daisy.setFieldLedsFromData($<data>);"
 		}
 	}

--- a/source/daisy.field.json
+++ b/source/daisy.field.json
@@ -177,15 +177,23 @@
 			"code": "(hardware.GetSwitch(1)->Pressed()?1.f:0.f);"
 		},
 		"cv1": {
+			"input_min": -1,
+			"input_max": 1,
 			"code": "hardware.GetCvValue(0);"
 		},
 		"cv2": {
+			"input_min": -1,
+			"input_max": 1,
 			"code": "hardware.GetCvValue(1);"
 		},
 		"cv3": {
+			"input_min": -1,
+			"input_max": 1,
 			"code": "hardware.GetCvValue(2);"
 		},
 		"cv4": {
+			"input_min": -1,
+			"input_max": 1,
 			"code": "hardware.GetCvValue(3);"
 		},
 		"gt1": {

--- a/source/daisy.patch_sm.json
+++ b/source/daisy.patch_sm.json
@@ -109,23 +109,19 @@
       "code": "hardware.GetAdcValue(daisy::patch_sm::CV_4);"
     },
     "cv5": {
-      "input_min": -1,
-      "input_max": 1,
+      "range": [-1, 1],
       "code": "hardware.GetAdcValue(daisy::patch_sm::CV_5);"
     },
     "cv6": {
-      "input_min": -1,
-      "input_max": 1,
+      "range": [-1, 1],
       "code": "hardware.GetAdcValue(daisy::patch_sm::CV_6);"
     },
     "cv7": {
-      "input_min": -1,
-      "input_max": 1,
+      "range": [-1, 1],
       "code": "hardware.GetAdcValue(daisy::patch_sm::CV_7);"
     },
     "cv8": {
-      "input_min": -1,
-      "input_max": 1,
+      "range": [-1, 1],
       "code": "hardware.GetAdcValue(daisy::patch_sm::CV_8);"
     },
     "gt1": {

--- a/source/daisy.patch_sm.json
+++ b/source/daisy.patch_sm.json
@@ -23,7 +23,8 @@
       "knob4": "kn4",
       "gate1": "gt1",
       "gate2": "gt2",
-
+      "switch": "sw",
+      "toggle": "sw",
       "sw": "sw",
       "sw1": "sw",
       "sw2": "button",
@@ -108,19 +109,23 @@
       "code": "hardware.GetAdcValue(daisy::patch_sm::CV_4);"
     },
     "cv5": {
-      "automap": true,
+      "input_min": -1,
+      "input_max": 1,
       "code": "hardware.GetAdcValue(daisy::patch_sm::CV_5);"
     },
     "cv6": {
-      "automap": true,
+      "input_min": -1,
+      "input_max": 1,
       "code": "hardware.GetAdcValue(daisy::patch_sm::CV_6);"
     },
     "cv7": {
-      "automap": true,
+      "input_min": -1,
+      "input_max": 1,
       "code": "hardware.GetAdcValue(daisy::patch_sm::CV_7);"
     },
     "cv8": {
-      "automap": true,
+      "input_min": -1,
+      "input_max": 1,
       "code": "hardware.GetAdcValue(daisy::patch_sm::CV_8);"
     },
     "gt1": {

--- a/source/daisy.pod.json
+++ b/source/daisy.pod.json
@@ -1,14 +1,23 @@
 {
-    "max_apps":1,
+	"max_apps": 1,
 	"defines": {
 		"OOPSY_TARGET_POD": 1,
 		"OOPSY_TARGET_HAS_MIDI_INPUT": 1,
 		"OOPSY_HAS_ENCODER": 1
 	},
-    "inserts": [
-		{ "where": "header", "code": "#include \"daisy_pod.h\"" },
-		{ "where": "header", "code": "typedef daisy::DaisyPod Daisy;" },
-		{ "where": "post_audio", "code": "hardware.UpdateLeds();" }
+	"inserts": [
+		{
+			"where": "header",
+			"code": "#include \"daisy_pod.h\""
+		},
+		{
+			"where": "header",
+			"code": "typedef daisy::DaisyPod Daisy;"
+		},
+		{
+			"where": "post_audio",
+			"code": "hardware.UpdateLeds();"
+		}
 	],
 	"labels": {
 		"params": {
@@ -18,7 +27,6 @@
 			"sw2": "sw2",
 			"sw3": "enp",
 			"encoder": "enc",
-
 			"ctrl1": "kn1",
 			"ctrl2": "kn2",
 			"switch1": "sw1",
@@ -32,7 +40,6 @@
 		"outs": {
 			"led1": "led1",
 			"led2": "led2",
-
 			"led": "led1"
 		},
 		"datas": {}
@@ -40,11 +47,11 @@
 	"inputs": {
 		"kn1": {
 			"automap": true,
-        	"code": "hardware.GetKnobValue(hardware.KNOB_1);"
+			"code": "hardware.GetKnobValue(hardware.KNOB_1);"
 		},
 		"kn2": {
 			"automap": true,
-        	"code": "hardware.GetKnobValue(hardware.KNOB_2);"
+			"code": "hardware.GetKnobValue(hardware.KNOB_2);"
 		},
 		"sw1": {
 			"code": "(hardware.button1.Pressed()?1.f:0.f);"
@@ -69,5 +76,5 @@
 			"code": "hardware.led2.Set(clamp(-$<name>, 0.f, 1.f), clamp($<name>, 0.f, 1.f), 0.f);"
 		}
 	},
-    "datahandlers": {}
+	"datahandlers": {}
 }

--- a/source/oopsy.js
+++ b/source/oopsy.js
@@ -1436,17 +1436,21 @@ function generate_app(app, hardware, target, config) {
 		if (src in hardware.inputs)
 		{
 			let input = hardware.inputs[src];
-			let input_min = input.input_min || 0;
-			let input_max = input.input_max || 1;
 
-			// We ignore this step if the fields are empty
-			if (input_min != 0 || input_max != 1)
+			if ('range' in input)
 			{
-				let new_range = node.range / (input_max - input_min);
-				node.range = new_range;
+				let input_min = input.range[0] || 0;
+				let input_max = input.range[1] || 1;
 
-				let new_min = node.min - input_min * new_range;
-				node.min = new_min;
+				// We ignore this step if the fields are default
+				if (input_min != 0 || input_max != 1)
+				{
+					let new_range = node.range / (input_max - input_min);
+					node.range = new_range;
+
+					let new_min = node.min - input_min * new_range;
+					node.min = new_min;
+				}
 			}
 		}
 

--- a/source/oopsy.js
+++ b/source/oopsy.js
@@ -1432,6 +1432,24 @@ function generate_app(app, hardware, target, config) {
 		node.src = src;
 		node.label = label;
 
+		// Apply input scaling
+		if (src in hardware.inputs)
+		{
+			let input = hardware.inputs[src];
+			let input_min = input.input_min || 0;
+			let input_max = input.input_max || 1;
+
+			// We ignore this step if the fields are empty
+			if (input_min != 0 || input_max != 1)
+			{
+				let new_range = node.range / (input_max - input_min);
+				node.range = new_range;
+
+				let new_min = node.min - input_min * new_range;
+				node.min = new_min;
+			}
+		}
+
 		let ideal_steps = 100 // about 4 good twists of the encoder
 		if (node.type == "bool" || node.type == "int") {
 			node.stepsize = 1


### PR DESCRIPTION
This PR permits negative inputs when using the range field in an input description, e.g.:

~~~json
{
  "inputs": {
    ...
    "cv5": {
      "range": [-1, 1],
      "code": "hardware.GetAdcValue(daisy::patch_sm::CV_5);"
    },
    ...
  }
}
~~~

This adjusts the scaling Oopsy does to factor in the different input range, preserving the expected behavior of the `@max` and `@min` param attributes. This addresses #60.

This fix applies only to old-style JSON files, as the new style has already implemented this functionality.