### PR TITLE
updated libdaisy to v4.0.0

### DIFF
--- a/source/genlib_daisy.h
+++ b/source/genlib_daisy.h
@@ -49,6 +49,9 @@ static bool      update = false;
 static const uint32_t OOPSY_SRAM_SIZE = 512 * 1024; 
 static const uint32_t OOPSY_SDRAM_SIZE = 64 * 1024 * 1024;
 
+// Added dedicated global SDFile to replace old global from libDaisy
+FIL SDFile;
+
 namespace oopsy {
 
 	uint32_t sram_used = 0, sram_usable = 0;
@@ -278,6 +281,8 @@ namespace oopsy {
 		#define OOPSY_WAV_WORKSPACE_BYTES (256)
 
 		daisy::SdmmcHandler handler;
+		daisy::FatFSInterface fsi;
+
 		uint8_t workspace[OOPSY_WAV_WORKSPACE_BYTES];
 		
 		void sdcard_init() {
@@ -287,8 +292,8 @@ namespace oopsy {
 			// sdconfig.speed           = daisy::SdmmcHandler::Speed::FAST;
 			sdconfig.width           = daisy::SdmmcHandler::BusWidth::BITS_1;
 			handler.Init(sdconfig);
-			dsy_fatfs_init();
-			f_mount(&SDFatFS, SDPath, 1);
+			fsi.Init(daisy::FatFSInterface::Config::MEDIA_SD);
+			f_mount(&fsi.GetSDFileSystem(), fsi.GetSDPath(), 1);
 		}
 
 		// TODO: resizing without wasting memory


### PR DESCRIPTION
Just a push on libDaisy itself. 

This resolves an issue that would cause the Daisy Patch to have issues when using the new Daisy Seed (1.1) due to the Daisy Patch's unique codec Initialization.