### PR TITLE
Gate polarity and bipolar fix

### DIFF
--- a/source/component_defs.json
+++ b/source/component_defs.json
@@ -104,10 +104,11 @@
 		]
 	},
 	"GateIn": {
-		"map_init": "dsy_gpio_pin {name}_pin = som.GetPin({pin});\n    {name}.Init(&{name}_pin);",
+		"map_init": "dsy_gpio_pin {name}_pin = som.GetPin({pin});\n    {name}.Init(&{name}_pin, {invert});",
 		"typename": "daisy::GateIn",
 		"direction": "in",
 		"pin": "a",
+		"invert": "true",
 		"mapping": [
 			{
 				"name": "{name}",

--- a/source/component_defs.json
+++ b/source/component_defs.json
@@ -379,7 +379,7 @@
 				"name": "{name}",
 				"get": "({class_name}.{name}.Value())",
 				"range": [
-					0,
+					-1,
 					1
 				],
 				"bool": false


### PR DESCRIPTION
This PR updates libdaisy and the json2daisy code to introduce a polarity option for GateIn objects. It also fixes a bug with BipolarAnalogControl components that prevents the negative voltages from being read.