### PR TITLE
Syntax error fix in Patch SM defs

### DIFF
--- a/source/component_defs_patchsm.json
+++ b/source/component_defs_patchsm.json
@@ -178,7 +178,7 @@
 		]
 	},
 	"Led": {
-		"map_init": "{name}.Init(daisy::patch_sm::DaisyPatchSM::{pin}), {invert});\n\t\t{name}.Set(0.0f);",
+		"map_init": "{name}.Init(daisy::patch_sm::DaisyPatchSM::{pin}, {invert});\n\t\t{name}.Set(0.0f);",
 		"typename": "daisy::Led",
 		"direction": "out",
 		"pin": "a",


### PR DESCRIPTION
This fixes an errant parenthesis in the Patch SM component defs that prevented compilation with Led components. Thanks to @[teddexter](https://forum.electro-smith.com/u/teddexter) on the forum for finding this!

I confirmed the change allows Patch SM based boards with an Led component to compile where they couldn't before.