### PR TITLE
Update patch.json

### DIFF
--- a/source/patch.json
+++ b/source/patch.json
@@ -2,7 +2,12 @@
 	"name": "patch",
 	"som": "seed",
 	"defines": {
-		"OOPSY_TARGET_HAS_MIDI_INPUT": 1
+		"OOPSY_TARGET_PATCH": 1,
+      		"OOPSY_TARGET_HAS_OLED": 1,
+      		"OOPSY_IO_COUNT": 4,
+      		"OOPSY_TARGET_HAS_MIDI_INPUT": 1,
+      		"OOPSY_TARGET_HAS_MIDI_OUTPUT": 1,
+      		"OOPSY_HAS_ENCODER": 1
 	},
 	"display": {},
 	"audio": {


### PR DESCRIPTION
Missing definitions for
"OOPSY_TARGET_PATCH": 1,
"OOPSY_TARGET_HAS_OLED": 1,
"OOPSY_IO_COUNT": 4,
"OOPSY_TARGET_HAS_MIDI_OUTPUT": 1,
"OOPSY_HAS_ENCODER": 1

Made flashing with the patch.json more or less useless as none of the peripherals was working.